### PR TITLE
MonadLogIO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.1.1
+=====
+
+*   Added `MonadLogIO` for loggers that allow to extract a log
+    function of type `LogFunctionIO`.
+
 0.1
 ===
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.1.1.1
+=======
+
+*   Add `NFData` instance for `LogPolicy`.
+
 0.1.1
 =====
 

--- a/src/System/Logger/Types.hs
+++ b/src/System/Logger/Types.hs
@@ -172,6 +172,8 @@ data LogPolicy
     | LogPolicyBlock
     deriving (Show, Read, Eq, Ord, Bounded, Enum, Typeable, Generic)
 
+instance NFData LogPolicy
+
 logPolicyText ∷ IsString s ⇒ LogPolicy → s
 logPolicyText LogPolicyDiscard = "discard"
 logPolicyText LogPolicyRaise = "raise"

--- a/src/System/Logger/Types.hs
+++ b/src/System/Logger/Types.hs
@@ -488,26 +488,26 @@ instance (MonadLog a m, MonadTransControl t, Monad n, n ~ (t m)) ⇒ MonadLog a 
 -- MonadLogIO
 
 instance (MonadLog a (ReaderT σ m), MonadLogIO a m) ⇒ MonadLogIO a (ReaderT σ m) where
-    logFunIO= lift logFunIO
+    logFunIO = lift logFunIO
     {-# INLINE logFunIO #-}
 
 instance (Monoid σ, MonadLogIO a m) ⇒ MonadLogIO a (WriterT σ m) where
-    logFunIO= lift logFunIO
+    logFunIO = lift logFunIO
     {-# INLINE logFunIO #-}
 
 instance (MonadLogIO a m) ⇒ MonadLogIO a (ExceptT ε m) where
-    logFunIO= lift logFunIO
+    logFunIO = lift logFunIO
     {-# INLINE logFunIO #-}
 
 instance (MonadLogIO a m) ⇒ MonadLogIO a (StateT σ m) where
-    logFunIO= lift logFunIO
+    logFunIO = lift logFunIO
     {-# INLINE logFunIO #-}
 
 instance (MonadLogIO a m) ⇒ MonadLogIO a (TraceT t e m) where
-    logFunIO= lift logFunIO
+    logFunIO = lift logFunIO
     {-# INLINE logFunIO #-}
 
 instance (MonadLogIO a m) ⇒ MonadLogIO a (EitherT σ m) where
-    logFunIO= lift logFunIO
+    logFunIO = lift logFunIO
     {-# INLINE logFunIO #-}
 

--- a/yet-another-logger.cabal
+++ b/yet-another-logger.cabal
@@ -1,5 +1,5 @@
 Name: yet-another-logger
-Version: 0.1
+Version: 0.1.1
 Synopsis: Yet Another Logger
 Description:
     A logging framework written with flexibility and performance
@@ -73,7 +73,7 @@ source-repository this
     type: git
     location: https://github.com/alephcloud/hs-yet-another-logger
     branch: master
-    tag: 0.1
+    tag: 0.1.1
 
 Library
     default-language: Haskell2010

--- a/yet-another-logger.cabal
+++ b/yet-another-logger.cabal
@@ -1,5 +1,5 @@
 Name: yet-another-logger
-Version: 0.1.1
+Version: 0.1.1.1
 Synopsis: Yet Another Logger
 Description:
     A logging framework written with flexibility and performance
@@ -73,7 +73,7 @@ source-repository this
     type: git
     location: https://github.com/alephcloud/hs-yet-another-logger
     branch: master
-    tag: 0.1.1
+    tag: 0.1.1.1
 
 Library
     default-language: Haskell2010


### PR DESCRIPTION
`MonadLogIO` is the class of loggers that allow to extract a log function of type `LogFunctionIO`.

``` haskell
-- | Instances of 'MonadLog' that allow to obtain a 'LogFunctionIO' as plain
-- value. This is helpful when dealing with frameworks that take a logging
-- function in 'IO' as parameter.
--
-- An instance of this class should apply the 'LogLevel', 'LogScope', and
-- 'LogPolicy' at the time when 'logFunIO' is called and not when the returned
-- action is excecuted. If the returned action is excecuted after the logger
-- got released or otherwise invalidated the behavior should match the behavior
-- on a congested logging pipeling accorrding to the log-policy that was in
-- scope when 'logFunIO' was called.
--
-- Even though it can be very convenient, instances of this class must be used
-- with care. The action may contain in its closure a reference to some
-- internal state of the 'MonadLog' instance. Beside of being a source of
-- potential memory leaks, there also is nothing that prevents a programer to
-- call this action outside of the valid scope of the 'MonadLog' instance. In
-- case that the context of the 'MonadLog' instance depends on some state that
-- gets explicitely deallocated this action may have unexectped behavior.
```
