### PR TITLE
Make the logger backend more robust

### DIFF
--- a/src/System/Logger/Logger.hs
+++ b/src/System/Logger/Logger.hs
@@ -44,6 +44,7 @@ module System.Logger.Logger
 , withLogger
 , withLogger_
 , withLogFunction
+, withLogFunction_
 
 -- * LoggerT Monad Transformer
 , LoggerT

--- a/src/System/Logger/Logger.hs
+++ b/src/System/Logger/Logger.hs
@@ -42,6 +42,7 @@ module System.Logger.Logger
 -- * Logger
 , Logger
 , withLogger
+, withLogger_
 , withLogFunction
 
 -- * LoggerT Monad Transformer

--- a/src/System/Logger/Logger.hs
+++ b/src/System/Logger/Logger.hs
@@ -60,6 +60,7 @@ module System.Logger.Logger
 , loggerConfigPolicy
 , loggerConfigExceptionLimit
 , loggerConfigExceptionWait
+, loggerConfigExitTimeout
 , defaultLoggerConfig
 , validateLoggerConfig
 , pLoggerConfig

--- a/src/System/Logger/Logger.hs
+++ b/src/System/Logger/Logger.hs
@@ -57,6 +57,9 @@ module System.Logger.Logger
 , loggerConfigQueueSize
 , loggerConfigThreshold
 , loggerConfigScope
+, loggerConfigPolicy
+, loggerConfigExceptionLimit
+, loggerConfigExceptionWait
 , defaultLoggerConfig
 , validateLoggerConfig
 , pLoggerConfig

--- a/src/System/Logger/Logger/Internal.hs
+++ b/src/System/Logger/Logger/Internal.hs
@@ -31,6 +31,7 @@
 -- module as an example and starting point.
 --
 
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -59,8 +60,10 @@ module System.Logger.Logger.Internal
 , loggerScope
 , loggerThreshold
 , createLogger
+, createLogger_
 , releaseLogger
 , withLogger
+, withLogger_
 , loggCtx
 , withLogFunction
 
@@ -72,6 +75,7 @@ module System.Logger.Logger.Internal
 
 import Configuration.Utils hiding (Lens', Error)
 
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async
 -- FIXME: use a better data structure with non-amortized complexity bounds
 import Control.Monad.STM
@@ -88,11 +92,15 @@ import Control.Monad.Unicode
 import Data.Monoid.Unicode
 import qualified Data.Text as T
 import Data.Typeable
+import qualified Data.Text as T
+import qualified Data.Text.IO as T (hPutStrLn)
+import Data.Void
 
 import GHC.Generics
 
 import Prelude.Unicode
 
+import System.IO (stderr)
 import System.Timeout
 
 -- internal modules
@@ -113,6 +121,15 @@ data LoggerConfig = LoggerConfig
         -- ^ initial stack of log labels, can be extended later on
     , _loggerConfigPolicy ∷ !LogPolicy
         -- ^ how to deal with a congested logging pipeline
+    , _loggerConfigExceptionLimit ∷ !(Maybe Int)
+        -- ^ number of consecutive backend exception that can occur before the logger
+        -- raises an 'BackendToManyExceptions' exception. If this is 'Nothing'
+        -- the logger will discard all exceptions. For instance a value of @1@
+        -- means that an exception is raised when the second exception occurs.
+        -- A value of @0@ means that an exception is raised for each exception.
+    , _loggerConfigExceptionWait ∷ !(Maybe Int)
+        -- ^ number of microseconds to wait after an exception from the backend.
+        -- If this is 'Nothing' the logger won't wait at all after an exception.
     }
     deriving (Show, Read, Eq, Ord, Typeable, Generic)
 
@@ -128,14 +145,28 @@ loggerConfigScope = lens _loggerConfigScope $ \a b → a { _loggerConfigScope = 
 loggerConfigPolicy ∷ Lens' LoggerConfig LogPolicy
 loggerConfigPolicy = lens _loggerConfigPolicy $ \a b → a { _loggerConfigPolicy = b }
 
+loggerConfigExceptionLimit ∷ Lens' LoggerConfig (Maybe Int)
+loggerConfigExceptionLimit = lens _loggerConfigExceptionLimit $ \a b → a { _loggerConfigExceptionLimit = b }
+
+loggerConfigExceptionWait ∷ Lens' LoggerConfig (Maybe Int)
+loggerConfigExceptionWait = lens _loggerConfigExceptionWait $ \a b → a { _loggerConfigExceptionWait = b }
+
 instance NFData LoggerConfig
 
+-- | Default Logger configuration
+--
+-- The exception limit for backend exceptions is 10 and the wait time between
+-- exceptions is 1000. This means that in case of a defunctioned backend the
+-- logger will exist by throwing an exception after at least one second.
+--
 defaultLoggerConfig ∷ LoggerConfig
 defaultLoggerConfig = LoggerConfig
     { _loggerConfigQueueSize = 1000
     , _loggerConfigThreshold = Warn
     , _loggerConfigScope = []
     , _loggerConfigPolicy = LogPolicyDiscard
+    , _loggerConfigExceptionLimit = Just 10
+    , _loggerConfigExceptionWait = Just 1000
     }
 
 validateLoggerConfig ∷ ConfigValidation LoggerConfig λ
@@ -147,6 +178,8 @@ instance ToJSON LoggerConfig where
         , "log_level" .= _loggerConfigThreshold
         , "scope" .= _loggerConfigScope
         , "policy" .= _loggerConfigPolicy
+        , "exception_limit" .= _loggerConfigExceptionLimit
+        , "exception_wait" .= _loggerConfigExceptionWait
         ]
 
 instance FromJSON (LoggerConfig → LoggerConfig) where
@@ -155,6 +188,8 @@ instance FromJSON (LoggerConfig → LoggerConfig) where
         <*< loggerConfigThreshold ..: "log_level" × o
         <*< loggerConfigScope ..: "scope" × o
         <*< loggerConfigPolicy ..: "policy" × o
+        <*< loggerConfigExceptionLimit ..: "exception_limit" × o
+        <*< loggerConfigExceptionWait ..: "exception_wait" × o
 
 pLoggerConfig ∷ MParser LoggerConfig
 pLoggerConfig = pLoggerConfig_ ""
@@ -170,6 +205,14 @@ pLoggerConfig_ prefix = id
         ⊕ help "size of the internal logger queue"
     <*< loggerConfigThreshold .:: pLogLevel_ prefix
     <*< loggerConfigPolicy .:: pLogPolicy_ prefix
+    <*< loggerConfigExceptionLimit .:: fmap Just × option auto
+        × long (T.unpack prefix ⊕ "exception-limit")
+        ⊕ metavar "INT"
+        ⊕ help "maximal number of backend failures before and exception is raised"
+    <*< loggerConfigExceptionWait .:: fmap Just × option auto
+        × long (T.unpack prefix ⊕ "exception-wait")
+        ⊕ metavar "INT"
+        ⊕ help "time to wait after an backend failure occured"
 
 -- -------------------------------------------------------------------------- --
 -- Logger
@@ -223,15 +266,71 @@ loggerMissed ∷ Lens' (Logger a) (TVar Int)
 loggerMissed = lens _loggerMissed $ \a b → a { _loggerMissed = b }
 {-# INLINE loggerMissed #-}
 
+-- | Create a new logger. A logger created with this function must be released
+-- with a call to 'releaseLogger' and must not be used after it is released.
+--
+-- The logger calls the backend function exactly once for each log message. If
+-- the backend throws an exception, the message is discarded and the exception
+-- is dealt with as follows:
+--
+-- 1. The exception is logged. First it is attempt to log to the backend itself.
+--    If that fails, due to another exception, the incident is logged to an
+--    alternate log sink, usually @T.putStrLn@ or just @const (return ())@.
+--
+-- 2. The message is discarded. If the backend exception is of type
+--    'BackendTerminatedException' the exception is rethrown by the logger which
+--    causes the logger to exit. Otherwise the exception is appended to the
+--    exception list.
+--
+-- 3. If the length of the exception list exceeds a configurable threshold
+--    a 'BackendToManyExceptions' exception is thrown (which causes the logger
+--    to terminate).
+--
+-- 4. Otherwise the logger waits for a configurable amount of time before
+--    proceeding.
+--
+-- 5. The next time the backend returns without throwing an exception the
+--    exception list is reset to @[]@.
+--
+-- Backends are expected to implement there own retry logic if required.
+-- Backends may base their behavoir on the 'LogPolicy' that is effective for a
+-- given message. Please refer to the documentation of 'LoggerBackend' for
+-- more details about how to implement and backend.
+--
+-- Backends are called synchronously. Backends authors must thus ensure that a
+-- backend returns promptly in accordance with the 'LogPolicy' and the size of
+-- the logger queue. For more elaborate failover strategies, such as batching
+-- retried messages with the delivery of new messages, backends may implement
+-- there only internal queue.
+--
+-- Exceptions of type 'BlockedIndefinitelyOnSTM' and 'NestedAtomically' are
+-- rethrowin immediately. Those exceptions indicate a bug in the code due to
+-- unsafe usage of 'createLogger'. This exceptions shouldn't be possible when
+-- 'withLogger' is used to provide the logger and and the reference to the
+-- logger isn't used outside the scope of the bracket.
+--
 createLogger
     ∷ MonadIO μ
     ⇒ LoggerConfig
     → LoggerBackend a
     → μ (Logger a)
-createLogger LoggerConfig{..} backend = liftIO $ do
+createLogger = createLogger_ (T.hPutStrLn stderr)
+
+-- | A version of 'createLogger' that takes as an extra argument
+-- a function for logging errors in the logging system.
+--
+createLogger_
+    ∷ MonadIO μ
+    ⇒ (T.Text → IO ())
+        -- ^ alternate sink for logging exceptions in the logger itself.
+    → LoggerConfig
+    → LoggerBackend a
+    → μ (Logger a)
+createLogger_ errLogFun LoggerConfig{..} backend = liftIO $ do
     queue ← newTBMQueueIO _loggerConfigQueueSize
     missed ← newTVarIO 0
-    worker ← backendWorker backend queue missed
+    worker ← backendWorker errLogFun _loggerConfigExceptionLimit _loggerConfigExceptionWait backend queue missed
+    link worker
     return $ Logger
         { _loggerQueue = queue
         , _loggerWorker = worker
@@ -241,27 +340,64 @@ createLogger LoggerConfig{..} backend = liftIO $ do
         , _loggerMissed = missed
         }
 
--- FIXME: make this more reliable
+-- | A backend worker.
 --
--- We must deal better with exceptions thrown by the backend: we should
--- use some reasonable re-spawn logic. Right now there is the risk of a
--- busy loop.
+-- The only way for this function to exist without an exception is when
+-- the interal logger queue is closed through a call to 'releaseLogger'.
 --
 backendWorker
-    ∷ LoggerBackend a
+    ∷ (T.Text → IO ())
+        -- ^ alternate sink for logging exceptions in the logger itself.
+    → Maybe Int
+        -- ^ number of consecutive backend exception that can occur before the logger
+        -- to raises an 'BackendToManyExceptions' exception. If this is 'Nothing'
+        -- the logger will discard all exceptions. For instance a value of @1@
+        -- means that an exception is raised when the second exception occurs.
+        -- A value of @0@ means that an exception is raised for each exception.
+    → Maybe Int
+        -- ^ number of microseconds to wait after an exception from the backend.
+        -- If this is 'Nothing' the logger won't wait at all after an exception.
+    → LoggerBackend a
     → LoggerQueue a
     → TVar Int
     → IO (Async ())
-backendWorker backend queue missed = async $ go `catchAny` \e → do
-    -- chances are that this fails, too...
-    (backend ∘ Left $ backendErrorMsg (sshow e)) `catchAny` (const $ return ())
-    go
+backendWorker errLogFun errLimit errWait backend queue missed = async $ go []
   where
-    go = atomically readMsg ≫= \case
-        -- when the queue is closed and empty the backendWorker returns
+
+    -- we assume that 'BlockedIndefinitelyOnSTM' and 'NestedAtomically' are the
+    -- only exceptions beside asynchronous exceptions that can be thrown by
+    -- @atomically readMsg@.
+    --
+    go errList = atomically readMsg ≫= \case
+
+        -- When the queue is closed and empty the backendWorker returns.
+        -- This is the only way for backendWorker to exist without an exception.
         Nothing → return ()
-        -- When there are still messages to process the backendWorker loops
-        Just msg → backend msg ≫ go
+
+        -- call backend for the message and loop
+        Just msg → runBackend errList msg ≫= go
+
+    runBackend errList msg = (backend msg ≫ return []) `catchAny` \e → do
+
+        -- try to log exception to backend
+        let errMsg = backendErrorMsg (sshow e)
+        backend (Left errMsg) `catchAny` \_ →
+            -- log exception to alternate sink
+            errLogFun (errLogMsg errMsg) `catchAny` \_ →
+                -- discard exception log
+                return ()
+
+        -- decide how to proceed in case of an error
+        case fromException e of
+            Just (BackendTerminatedException _ ∷ LoggerException Void) → throwIO e
+            _ → do
+                maybe (return ()) threadDelay errWait
+                let errList' = e:errList
+                case errLimit of
+                    Nothing → return []
+                    Just n
+                        | length errList' > n → throwIO $ BackendToManyExceptions (reverse errList')
+                        | otherwise → return errList'
 
     -- As long as the queue is not closed and empty this retries until
     -- a new message arrives
@@ -281,11 +417,21 @@ backendWorker backend queue missed = async $ go `catchAny` \e → do
         , _logMsgScope = [("system", "logger")]
         }
 
+    -- A log message that informs about an error in the backend
     backendErrorMsg e = LogMessage
         { _logMsg = e
         , _logMsgLevel = Error
         , _logMsgScope = [("system", "logger"), ("component", "backend")]
         }
+
+    -- format a log message that is written to the error sink
+    errLogMsg LogMessage{..} = T.unwords
+        [ "[" ⊕ logLevelText _logMsgLevel ⊕ "]"
+        , formatScope _logMsgScope
+        , _logMsg
+        ]
+    formatScope scope = "[" ⊕ T.intercalate "," (map formatLabel scope) ⊕ "]"
+    formatLabel (k,v) = "(" ⊕ k ⊕ "," ⊕ v ⊕ ")"
 
 releaseLogger
     ∷ MonadIO μ
@@ -324,14 +470,30 @@ releaseLogger t Logger{..} = liftIO $ do
 -- >  where
 -- >    waitTimeout = Just 3000000
 --
+-- For detailed information about how backends are executed refer
+-- to the documentation of 'createLogger'.
+--
 withLogger
     ∷ (MonadIO μ, MonadBaseControl IO μ)
     ⇒ LoggerConfig
     → LoggerBackend a
     → (Logger a → μ α)
     → μ α
-withLogger config backend =
-    bracket (createLogger config backend) (releaseLogger waitTimeout)
+withLogger = withLogger_ (T.hPutStrLn stderr)
+
+-- | A version of 'withLogger' that takes as an extra argument
+-- a function for logging errors in the logging system.
+--
+withLogger_
+    ∷ (MonadIO μ, MonadBaseControl IO μ)
+    ⇒ (T.Text → IO ())
+        -- ^ alternate sink for logging exceptions in the logger itself.
+    → LoggerConfig
+    → LoggerBackend a
+    → (Logger a → μ α)
+    → μ α
+withLogger_ errLogFun config backend =
+    bracket (createLogger_ errLogFun config backend) (releaseLogger waitTimeout)
   where
     waitTimeout = Just 3000000
 
@@ -348,12 +510,6 @@ withLogFunction config backend f = withLogger config backend $ f ∘ loggCtx
 
 -- -------------------------------------------------------------------------- --
 -- Log Function
-
-data LoggerException a
-    = QueueFullException (LogMessage a)
-    deriving (Show, Eq, Ord, Typeable, Generic)
-
-instance (Typeable a, Show a) ⇒ Exception (LoggerException a)
 
 -- Log a message with the given logger context
 --

--- a/src/System/Logger/Logger/Internal.hs
+++ b/src/System/Logger/Logger/Internal.hs
@@ -50,6 +50,9 @@ module System.Logger.Logger.Internal
 , loggerConfigQueueSize
 , loggerConfigThreshold
 , loggerConfigScope
+, loggerConfigPolicy
+, loggerConfigExceptionLimit
+, loggerConfigExceptionWait
 , defaultLoggerConfig
 , validateLoggerConfig
 , pLoggerConfig

--- a/src/System/Logger/Logger/Internal.hs
+++ b/src/System/Logger/Logger/Internal.hs
@@ -328,9 +328,9 @@ loggerExitTimeout = lens _loggerExitTimeout $ \a b → a { _loggerExitTimeout = 
 -- there only internal queue.
 --
 -- Exceptions of type 'BlockedIndefinitelyOnSTM' and 'NestedAtomically' are
--- rethrowin immediately. Those exceptions indicate a bug in the code due to
+-- rethrown immediately. Those exceptions indicate a bug in the code due to
 -- unsafe usage of 'createLogger'. This exceptions shouldn't be possible when
--- 'withLogger' is used to provide the logger and and the reference to the
+-- 'withLogger' is used to provide the logger and the reference to the
 -- logger isn't used outside the scope of the bracket.
 --
 createLogger

--- a/src/System/Logger/Logger/Internal.hs
+++ b/src/System/Logger/Logger/Internal.hs
@@ -96,7 +96,6 @@ import Control.Monad.Unicode
 import Data.Monoid.Unicode
 import qualified Data.Text as T
 import Data.Typeable
-import qualified Data.Text as T
 import qualified Data.Text.IO as T (hPutStrLn)
 import Data.Void
 

--- a/src/System/Logger/Logger/Internal.hs
+++ b/src/System/Logger/Logger/Internal.hs
@@ -401,7 +401,7 @@ backendWorker errLogFun errLimit errWait backend queue missed = mask_ $
     go errList = atomically readMsg ≫= \case
 
         -- When the queue is closed and empty the backendWorker returns.
-        -- This is the only way for backendWorker to exist without an exception.
+        -- This is the only way for backendWorker to exit without an exception.
         Nothing → return ()
 
         -- call backend for the message and loop

--- a/src/System/Logger/Logger/Internal.hs
+++ b/src/System/Logger/Logger/Internal.hs
@@ -70,6 +70,7 @@ module System.Logger.Logger.Internal
 , withLogger_
 , loggCtx
 , withLogFunction
+, withLogFunction_
 
 -- * LoggerT Monad Transformer
 , LoggerT
@@ -517,7 +518,21 @@ withLogFunction
     → LoggerBackend a
     → (LogFunctionIO a → μ α)
     → μ α
-withLogFunction config backend f = withLogger config backend $ f ∘ loggCtx
+withLogFunction = withLogFunction_ (T.hPutStrLn stderr)
+
+-- | For simple cases, when the logger threshold and the logger scope is
+-- constant this function can be used to directly initialize a log function.
+--
+withLogFunction_
+    ∷ (Show a, Typeable a, NFData a, MonadIO μ, MonadBaseControl IO μ)
+    ⇒ (T.Text → IO ())
+        -- ^ alternate sink for logging exceptions in the logger itself.
+    → LoggerConfig
+    → LoggerBackend a
+    → (LogFunctionIO a → μ α)
+    → μ α
+withLogFunction_ errLogFun config backend f =
+    withLogger_ errLogFun config backend $ f ∘ loggCtx
 
 -- -------------------------------------------------------------------------- --
 -- Log Function

--- a/src/System/Logger/Types.hs
+++ b/src/System/Logger/Types.hs
@@ -273,7 +273,7 @@ logMsgScope = lens _logMsgScope $ \a b → a { _logMsgScope = b }
 instance NFData a ⇒ NFData (LogMessage a)
 
 -- | This is given to logger when it is created. It formats and delivers
--- individual log messages synchronously. The backend is called once ofr each
+-- individual log messages synchronously. The backend is called once for each
 -- log message (that meets the required log level).
 --
 -- The type parameter @a@ is expected to provide instances for 'Show'
@@ -295,7 +295,7 @@ instance NFData a ⇒ NFData (LogMessage a)
 -- harder in case of 'LogPolicyBlock'.
 --
 -- TODO there may be scenarios where chunked processing is beneficial. While
--- this can be done in a closure of this function a more direct support might
+-- this can be done in a closure of this function, more direct support might
 -- be desirable.
 --
 type LoggerBackend a = Either (LogMessage T.Text) (LogMessage a) → IO ()

--- a/src/System/Logger/Types.hs
+++ b/src/System/Logger/Types.hs
@@ -25,6 +25,7 @@
 -- Stability: experimental
 --
 
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -60,6 +61,9 @@ module System.Logger.Types
 , LogLabel
 , LogScope
 
+-- * Logger Exception
+, LoggerException(..)
+
 -- * Logger Backend
 , LogMessage(..)
 , logMsg
@@ -87,6 +91,7 @@ module System.Logger.Types
 import Configuration.Utils hiding (Lens', Error)
 
 import Control.DeepSeq
+import Control.Exception
 import Control.Lens hiding ((.=))
 import Control.Monad.Base
 import Control.Monad.Except
@@ -105,6 +110,7 @@ import Data.String
 import qualified Data.Text as T
 import Data.Text.Lens
 import Data.Typeable
+import Data.Void
 
 import GHC.Generics
 
@@ -223,6 +229,18 @@ type LogLabel = (T.Text, T.Text)
 type LogScope = [LogLabel]
 
 -- -------------------------------------------------------------------------- --
+-- Logger Exception
+
+data LoggerException a where
+    QueueFullException ∷ LogMessage a → LoggerException a
+    BackendTerminatedException ∷ SomeException → LoggerException Void
+    BackendToManyExceptions ∷ [SomeException] → LoggerException Void
+    deriving (Typeable)
+
+deriving instance Show a ⇒ Show (LoggerException a)
+instance (Typeable a, Show a) ⇒ Exception (LoggerException a)
+
+-- -------------------------------------------------------------------------- --
 -- Backend
 
 -- | The Internal log message type.
@@ -255,20 +273,30 @@ logMsgScope = lens _logMsgScope $ \a b → a { _logMsgScope = b }
 instance NFData a ⇒ NFData (LogMessage a)
 
 -- | This is given to logger when it is created. It formats and delivers
--- individual log messages synchronously.
+-- individual log messages synchronously. The backend is called once ofr each
+-- log message (that meets the required log level).
 --
 -- The type parameter @a@ is expected to provide instances for 'Show'
 -- 'Typeable', and 'NFData'.
 --
--- The 'Left' values of the argument allows the generation of log messages
--- that are independent of the parameter @a@. The motivation for this is
--- reporting issues in Logging system itself, like a full logger queue
--- or providing statistics about the fill level of the queue. There may
--- be other uses of this, too.
+-- The 'Left' values of the argument allows the generation of log messages that
+-- are independent of the parameter @a@. The motivation for this is reporting
+-- issues in Logging system itself, like a full logger queue or providing
+-- statistics about the fill level of the queue. There may be other uses of
+-- this, too.
 --
--- TODO there may be scenarios where chunked processing is beneficial.
--- While this can be done in a closure of this function a more direct
--- support might be desirable.
+-- Backends that can fail are encouraged (but not forced) to take into account
+-- the 'LogPolicy' that is effective for a message. For instance, a backend may
+-- implement a reasonable retry logic for each message and then raise a
+-- 'BackendTerminatedException' in case the policy is 'LogPolicyBlock' or
+-- 'LogPolicyRaise' (thus causing the logger to exit immediately) and raise
+-- some other exception otherwise (thus discarding the message without causing
+-- the logger to not exit immediately). In addition a backend might retry
+-- harder in case of 'LogPolicyBlock'.
+--
+-- TODO there may be scenarios where chunked processing is beneficial. While
+-- this can be done in a closure of this function a more direct support might
+-- be desirable.
 --
 type LoggerBackend a = Either (LogMessage T.Text) (LogMessage a) → IO ()
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,0 +1,39 @@
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
+--
+-- NOTICE: The dissemination, reproduction, or copying of this file and the
+-- information contained herein, in any medium, is strictly forbidden.
+--
+-- The intellectual property and technical concepts contained herein are
+-- proprietary to PivotCloud and are protected by U.S. and Foreign law.
+
+-- |
+-- Module: Main
+-- Copyright: Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
+-- License: All Rights Reserved, see LICENSE file of the package
+-- Maintainer: code@pivotmail.com
+-- Stability: experimental
+--
+-- Test suite for yet-another-logger
+--
+
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE UnicodeSyntax #-}
+
+module Main
+(main
+) where
+
+import Test.Tasty
+
+-- internal
+import qualified NoBackend
+
+main ∷ IO ()
+main = defaultMain $
+    NoBackend.tests
+

--- a/test/NoBackend.hs
+++ b/test/NoBackend.hs
@@ -7,7 +7,7 @@
 -- proprietary to PivotCloud and are protected by U.S. and Foreign law.
 
 -- |
--- Module: Main
+-- Module: NoBackend
 -- Copyright: Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
 -- License: All Rights Reserved, see LICENSE file of the package
 -- Maintainer: code@pivotmail.com

--- a/test/NoBackend.hs
+++ b/test/NoBackend.hs
@@ -1,0 +1,320 @@
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
+--
+-- NOTICE: The dissemination, reproduction, or copying of this file and the
+-- information contained herein, in any medium, is strictly forbidden.
+--
+-- The intellectual property and technical concepts contained herein are
+-- proprietary to PivotCloud and are protected by U.S. and Foreign law.
+
+-- |
+-- Module: Main
+-- Copyright: Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
+-- License: All Rights Reserved, see LICENSE file of the package
+-- Maintainer: code@pivotmail.com
+-- Stability: experimental
+--
+
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE UnicodeSyntax #-}
+
+module NoBackend
+( tests
+) where
+
+import Control.Concurrent
+import Control.Concurrent.Async
+import Control.Exception
+import Control.Exception.Enclosed
+import Control.Monad
+import Control.Monad.Unicode
+import Control.Lens
+
+import Data.IORef
+import Data.Monoid.Unicode
+import Data.String
+import qualified Data.Text as T
+import Data.Typeable
+import Data.Void
+
+import GHC.Generics
+
+import Prelude.Unicode
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+-- pc-directory
+import System.Logger
+
+-- -------------------------------------------------------------------------- --
+-- TestParams
+
+data TestParams = TestParams
+    { queueSize ∷ !Int
+        -- ^ queue size
+    , threadsN ∷ !Int
+        -- ^ number of threads
+    , messageN ∷ !Int
+        -- ^ number of log message to write
+    , messageSize ∷ !Int
+        -- ^ size of message
+    , frontendDelay ∷ !Int
+        -- ^ delay between messages in microseconds
+    , backendDelay ∷ !Int
+        -- ^ write delay in microseconds
+    , exitDelay ∷ !(Maybe Int)
+        -- ^ exit timeout in microseconds
+    }
+    deriving (Show, Read, Eq, Ord, Typeable, Generic)
+
+-- -------------------------------------------------------------------------- --
+-- Test Vectors
+
+tests ∷ TestTree
+tests = testGroup "trivial backend"
+    [ noBackendTests
+        [ TestParams 10 100 100 1000 25 1 (Just t)
+        , TestParams 1000 100 100 10000 25 1 (Just t)
+        , TestParams 10000000 100 100 10000 25 1 (Just t)
+
+        , TestParams 10 100 100 1000 10 1 (Just t)
+        , TestParams 1000 100 100 10000 10 1 (Just t)
+        , TestParams 10000000 100 100 10000 10 1 (Just t)
+
+        , TestParams 10 100 100 1000 1 5 (Just t)
+        , TestParams 1000 100 100 10000 1 5 (Just t)
+        , TestParams 10000000 100 100 10000 1 5 (Just t)
+        ]
+    , buggyBackendTests 11 10
+        [ TestParams 10 10 100 1000 25 1 (Just 10)
+        , TestParams 1000 100 100 10000 25 1 (Just 10)
+        , TestParams 10000000 100 100 10000 25 1 (Just 10)
+        ]
+    , buggyRecoverBackendTests 2 10
+        [ TestParams 10 100 100 1000 100 1 (Just 10)
+        , TestParams 1000 100 100 1000 10 1 (Just 10)
+        , TestParams 10000000 100 100 1000 10 1 (Just 10)
+        ]
+    , buggyRecoverBackendTests 8 10
+        [ TestParams 1000 10 100 100 100 1 (Just 10)
+        ]
+    , buggyNoRecoverBackendTests 10 15
+        [ TestParams 1000 10 100 100 100 1 (Just 10)
+        ]
+    ]
+  where
+    t = 1
+
+noBackendTests ∷ [TestParams] → TestTree
+noBackendTests = testGroup "no backend" ∘ map tc
+  where
+    tc args = testCaseSteps (show args) $ \logLogStr →
+        catchAny
+            (noBackendLoggerTest (logLogStr ∘ T.unpack) args)
+            (\e → assertString $ "exception: " ⊕ show e)
+
+-- Buggy Backend that calls 'BackendTerminatedException'.
+--
+buggyBackendTests ∷ Int → Int → [TestParams] → TestTree
+buggyBackendTests m n =
+    testGroup ("buggy backend " ⊕ sshow m ⊕ " " ⊕ sshow n) ∘ map tc
+  where
+    tc args = testCaseSteps (show args) $ \logLogStr →
+        do
+            buggyBackendLoggerTest exception (\x → x `mod` m <= n) (logLogStr ∘ T.unpack) args
+            assertString $ "Missing expected exception"
+        `catch` \(e ∷ LoggerException Void) → case e of
+            BackendTerminatedException e0 → case fromException e0 of
+                Just BuggyBackendException → logLogStr $ "test: expected exception: " ⊕ show e
+                _ → throwIO e
+            _ → throwIO e
+    exception = BackendTerminatedException $ toException BuggyBackendException
+
+-- | Buggy Backend that calls some exception.
+--
+-- The logger is expected to recover.
+--
+buggyRecoverBackendTests ∷ Int → Int → [TestParams] → TestTree
+buggyRecoverBackendTests m n =
+    testGroup ("buggy recover backend " ⊕ sshow m ⊕ " " ⊕ sshow n) ∘ map tc
+  where
+    tc args = testCaseSteps (show args) $ \logLogStr →
+        do
+            buggyBackendLoggerTest exception (\x → x `mod` n <= m) (logLogStr ∘ T.unpack) args
+        `catchAny` \e →
+            assertString $ "exception: " ⊕ show e
+    exception = BuggyBackendException
+
+-- | Buggy Backend that calls some exception.
+--
+-- The logger is expected to throw 'BackendToManyExceptions'.
+--
+buggyNoRecoverBackendTests ∷ Int → Int → [TestParams] → TestTree
+buggyNoRecoverBackendTests m n =
+    testGroup ("buggy no recover backend " ⊕ sshow m ⊕ " " ⊕ sshow n) ∘ map tc
+  where
+    tc args = testCaseSteps (show args) $ \logLogStr →
+        (do
+            buggyBackendLoggerTest exception (\x → x `mod` n <= m) (logLogStr ∘ T.unpack) args
+            assertString $ "Missing expected exception: " ⊕ sshow exception
+        `catch` \(e ∷ LoggerException Void) → do
+            logLogStr $ "caught:" ⊕ sshow e
+            case e of
+                BackendToManyExceptions (e0:_) → case fromException e0 of
+                    Just BuggyBackendException → logLogStr $ "test: expected exception: " ⊕ sshow e
+                    _ → throwIO e
+                _ → throwIO e)
+        `catchAny` \e → logLogStr $ "caught any: " ⊕ sshow e
+    exception = BuggyBackendException
+
+-- -------------------------------------------------------------------------- --
+-- Test Backend
+
+-- | A thread that logs messages
+--
+testThread
+    ∷ Int
+        -- ^ number of log message to write
+    → Int
+        -- ^ size of message
+    → Int
+        -- ^ delay between messages in microseconds
+    → LogFunctionIO T.Text
+    → IO ()
+testThread n s delayMicro logFun = do
+    void ∘ replicateM n $ do
+        threadDelay delayMicro
+        logFun Debug msg
+  where
+    msg = T.replicate s "a"
+
+-- | A backend that logs all messages with level at least Warning
+-- and discards all other messages.
+--
+-- Assuming that all test messages are of level lower than Warning
+-- this will log only messages that are generated by the logging
+-- framework itself.
+--
+testBackend
+    ∷ Show msg
+    ⇒ (T.Text → IO ())
+    → Int
+        -- ^ minimal delay before returning in microseconds
+    → LoggerBackend msg
+testBackend _logLog delayMicro (Right LogMessage{..}) =
+    -- simulate deliver by applying the delay
+    threadDelay delayMicro ≫ return ()
+
+testBackend logLog delayMicro (Left LogMessage{..}) = do
+    -- assume that the message comes from the logging system itself.
+    -- simulate delivery by applying the delay.
+    logLog $ "[" ⊕ logLevelText _logMsgLevel ⊕ "] " ⊕ sshow _logMsg
+    threadDelay delayMicro
+
+-- -------------------------------------------------------------------------- --
+-- No Backend Logger
+
+noBackendLoggerTest
+    ∷ (T.Text → IO ())
+    → TestParams
+    → IO ()
+noBackendLoggerTest logLog TestParams{..} =
+    nobackendLogger logLog config backendDelay $ \logFun →
+        testClients logFun `catchAny` \e → logLog ("exception in client: " ⊕ sshow e)
+  where
+    testClients logFun = do
+        s ← replicateM threadsN .
+            async ∘ void $ testThread messageN messageSize frontendDelay logFun
+        mapM_ wait s
+    config = defaultLoggerConfig
+        & loggerConfigThreshold .~ Debug
+        & loggerConfigQueueSize .~ queueSize
+        & loggerConfigExitTimeout .~ exitDelay
+
+-- | A logger with the testBackend.
+--
+nobackendLogger
+    ∷ (T.Text → IO ())
+    → LoggerConfig
+    → Int
+        -- ^ write delay in microseconds
+    → (LogFunctionIO T.Text → IO ())
+    → IO ()
+nobackendLogger logLog config delayMicro =
+    withLogFunction_ logLog config (testBackend logLog delayMicro)
+
+data BuggyBackendException = BuggyBackendException
+    deriving (Show, Read, Eq, Ord, Typeable, Generic)
+
+instance Exception BuggyBackendException
+
+-- -------------------------------------------------------------------------- --
+-- Buggy backend
+
+buggyBackendLoggerTest
+    ∷ Exception e
+    ⇒ e
+    → (Int → Bool)
+        -- ^ exception predicate
+    → (T.Text → IO ())
+    → TestParams
+    → IO ()
+buggyBackendLoggerTest exception isException logLog TestParams{..} =
+    buggyBackendLogger exception isException logLog config backendDelay $ \logFun →
+        testClients logFun `catchAny` \e → logLog ("exception in client: " ⊕ sshow e)
+  where
+    testClients logFun = do
+        s ← replicateM threadsN .
+            async ∘ void $ testThread messageN messageSize frontendDelay logFun
+        mapM_ wait s
+    config = defaultLoggerConfig
+        & loggerConfigThreshold .~ Debug
+        & loggerConfigQueueSize .~ queueSize
+        & loggerConfigExitTimeout .~ exitDelay
+
+-- | A logger with the testBackend the throw exceptions.
+--
+buggyBackendLogger
+    ∷ Exception e
+    ⇒ e
+    → (Int → Bool)
+        -- ^ exception predicate
+    → (T.Text → IO ())
+    → LoggerConfig
+    → Int
+        -- ^ write delay in microseconds
+    → (LogFunctionIO T.Text → IO ())
+    → IO ()
+buggyBackendLogger exception isException logLog config delayMicro f =
+    withBackend $ \backend → withLogFunction_ logLog config backend f
+  where
+    withBackend inner = do
+        counter ← newIORef (0 ∷ Int)
+        result ← inner $ \msg → case msg of
+            -- test log message
+            Right{} → do
+                modifyIORef' counter succ
+                c ← readIORef counter
+                if isException c
+                    then throwIO exception
+                    else testBackend logLog delayMicro msg
+            -- internal log message (we don't count these)
+            Left{} → testBackend logLog delayMicro msg
+        n ← readIORef counter
+        logLog $ "test: delivered " ⊕ sshow n ⊕ " log messages"
+        return result
+
+-- -------------------------------------------------------------------------- --
+-- Utils
+
+sshow ∷ (Show a, IsString b) ⇒ a → b
+sshow = fromString ∘ show
+

--- a/test/NoBackend.hs
+++ b/test/NoBackend.hs
@@ -51,7 +51,7 @@ import Prelude.Unicode
 import Test.Tasty
 import Test.Tasty.HUnit
 
--- pc-directory
+-- yet-another-logger
 import System.Logger
 
 -- -------------------------------------------------------------------------- --

--- a/test/NoBackend.hs
+++ b/test/NoBackend.hs
@@ -80,19 +80,9 @@ data TestParams = TestParams
 
 tests ∷ TestTree
 tests = testGroup "trivial backend"
-    [ noBackendTests
-        [ TestParams 10 100 100 1000 25 1 (Just t)
-        , TestParams 1000 100 100 10000 25 1 (Just t)
-        , TestParams 10000000 100 100 10000 25 1 (Just t)
-
-        , TestParams 10 100 100 1000 10 1 (Just t)
-        , TestParams 1000 100 100 10000 10 1 (Just t)
-        , TestParams 10000000 100 100 10000 10 1 (Just t)
-
-        , TestParams 10 100 100 1000 1 5 (Just t)
-        , TestParams 1000 100 100 10000 1 5 (Just t)
-        , TestParams 10000000 100 100 10000 1 5 (Just t)
-        ]
+    [ noBackendTestsTimeout 1
+    , noBackendTestsTimeout 100
+    , noBackendTestsTimeout 100000000
     , buggyBackendTests 11 10
         [ TestParams 10 10 100 1000 25 1 (Just 10)
         , TestParams 1000 100 100 10000 25 1 (Just 10)
@@ -111,7 +101,19 @@ tests = testGroup "trivial backend"
         ]
     ]
   where
-    t = 1
+    noBackendTestsTimeout t = noBackendTests
+        [ TestParams 10 100 100 1000 25 1 (Just t)
+        , TestParams 1000 100 100 10000 25 1 (Just t)
+        , TestParams 10000000 100 100 10000 25 1 (Just t)
+
+        , TestParams 10 100 100 1000 10 1 (Just t)
+        , TestParams 1000 100 100 10000 10 1 (Just t)
+        , TestParams 10000000 100 100 10000 10 1 (Just t)
+
+        , TestParams 10 100 100 1000 1 5 (Just t)
+        , TestParams 1000 100 100 10000 1 5 (Just t)
+        , TestParams 10000000 100 100 10000 1 5 (Just t)
+        ]
 
 noBackendTests ∷ [TestParams] → TestTree
 noBackendTests = testGroup "no backend" ∘ map tc

--- a/test/TastyTools.hs
+++ b/test/TastyTools.hs
@@ -1,0 +1,139 @@
+-- Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
+--
+-- NOTICE: The dissemination, reproduction, or copying of this file and the
+-- information contained herein, in any medium, is strictly forbidden.
+--
+-- The intellectual property and technical concepts contained herein are
+-- proprietary to PivotCloud and are protected by U.S. and Foreign law.
+
+-- |
+-- Module: TastyTools
+-- Copyright: Copyright (c) 2013-2015 PivotCloud, Inc. All Rights Reserved.
+-- License: All Rights Reserved, see LICENSE file of the package
+-- Maintainer: code@pivotmail.com
+-- Stability: experimental
+--
+
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE UnicodeSyntax #-}
+
+module TastyTools
+( ProgressFunction
+, TestCaseProgress
+, testCaseProgress
+
+, StepFunction
+, testCaseSteps
+) where
+
+import Configuration.Utils (boolReader)
+
+import Control.Applicative
+import Control.Exception (try)
+import Control.Monad
+import Control.Monad.IO.Class
+
+import Data.IORef.Lifted
+import Data.Monoid.Unicode
+import Data.Tagged
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as LT
+import qualified Data.Text.Lazy.Builder as LT
+import Data.Typeable
+
+import GHC.Generics
+
+import Prelude.Unicode
+
+import Test.Tasty
+import Test.Tasty.HUnit hiding (testCaseSteps)
+import Test.Tasty.Options
+import Test.Tasty.Providers
+
+newtype OptionVerbose = OptionVerbose Bool
+    deriving (Show, Read, Eq, Ord, Typeable, Generic)
+
+instance IsOption OptionVerbose where
+    defaultValue = OptionVerbose False
+    parseValue s = OptionVerbose <$> either (\(_::T.Text) → Nothing) Just (boolReader s)
+    optionName = Tagged "verbose"
+    optionHelp = Tagged "verbosely log test progress messages to the console"
+
+-- | Function to report progress
+--
+type ProgressFunction
+    = MonadIO m
+    ⇒ Float
+        -- ^ progress measure
+    → T.Text
+        -- ^ progress message
+    → m ()
+
+newtype TestCaseProgress = TestCaseProgress (ProgressFunction → Assertion)
+    deriving (Typeable)
+
+instance IsTest TestCaseProgress where
+    run opts (TestCaseProgress testAssertion) prog = do
+        outRef ← newIORef ""
+        try (testAssertion $ step outRef) >>= \case
+            Left (HUnitFailure errMsg) → if verbose
+              then do
+                output ← readIORef outRef
+                return ∘ testFailed ∘ LT.unpack ∘ LT.toLazyText $
+                    output ⊕ "\n" ⊕ LT.fromString errMsg
+              else
+                return ∘ testFailed $ errMsg
+            Right () → if verbose
+                then
+                    testPassed ∘ LT.unpack ∘ LT.toLazyText <$> readIORef outRef
+                else
+                    return $ testPassed ""
+      where
+
+        OptionVerbose verbose = lookupOption opts
+
+        step ∷ MonadIO m ⇒ IORef LT.Builder → Float → T.Text → m ()
+        step outRef p nm = liftIO $ do
+            prog $ Progress (T.unpack nm) p
+            when verbose $ atomicModifyIORef' outRef $ \l ->
+                (l ⊕ "\n" ⊕ LT.fromText nm, ())
+
+    testOptions = Tagged [Option (Proxy ∷ Proxy OptionVerbose)]
+
+-- | Constructor for a 'TestTree' which can emit progress messages
+--
+testCaseProgress
+    ∷ T.Text
+        -- ^ Test name
+    → (ProgressFunction → Assertion)
+        -- ^ test method
+    → TestTree
+testCaseProgress testName = singleTest (T.unpack testName) ∘ TestCaseProgress
+
+-- -------------------------------------------------------------------------- --
+-- Step
+
+-- | Function to report progress
+--
+type StepFunction
+    = MonadIO m
+    ⇒ T.Text
+        -- ^ progress message
+    → m ()
+
+-- | Constructor for a 'TestTree' which can emit progress messages
+--
+testCaseSteps
+    ∷ T.Text
+        -- ^ Test name
+    → (StepFunction → Assertion)
+        -- ^ test method
+    → TestTree
+testCaseSteps testName inner = singleTest (T.unpack testName) ∘ TestCaseProgress $ \f →
+    inner (f 0)
+

--- a/yet-another-logger.cabal
+++ b/yet-another-logger.cabal
@@ -115,3 +115,26 @@ Library
 
     ghc-options: -Wall
 
+test-suite tests
+    type: exitcode-stdio-1.0
+    default-language: Haskell2010
+    hs-source-dirs: test
+    main-is: Main.hs
+
+    other-modules:
+        NoBackend
+
+    build-depends:
+        async >= 2.0,
+        base == 4.*,
+        enclosed-exceptions >= 1.0,
+        lens >= 4.7,
+        tasty >= 0.10,
+        tasty-hunit >= 0.9,
+        text >= 1.2,
+        base-unicode-symbols >= 0.2,
+        yet-another-logger,
+        void
+
+    ghc-options: -Wall -threaded -with-rtsopts=-N
+

--- a/yet-another-logger.cabal
+++ b/yet-another-logger.cabal
@@ -123,18 +123,24 @@ test-suite tests
 
     other-modules:
         NoBackend
+        TastyTools
 
     build-depends:
         async >= 2.0,
         base == 4.*,
+        base-unicode-symbols >= 0.2,
+        configuration-tools >= 0.2.12,
         enclosed-exceptions >= 1.0,
         lens >= 4.7,
+        lifted-base >= 0.2,
+        tagged >= 0.7,
         tasty >= 0.10,
         tasty-hunit >= 0.9,
         text >= 1.2,
-        base-unicode-symbols >= 0.2,
-        yet-another-logger,
-        void
+        transformers >= 0.3,
+        transformers-base >= 0.4,
+        void >= 0.7,
+        yet-another-logger
 
     ghc-options: -Wall -threaded -with-rtsopts=-N
 

--- a/yet-another-logger.cabal
+++ b/yet-another-logger.cabal
@@ -110,7 +110,8 @@ Library
         text >= 1.2,
         trace >= 0.1,
         transformers >= 0.3,
-        transformers-base >= 0.4
+        transformers-base >= 0.4,
+        void >= 0.7
 
     ghc-options: -Wall
 


### PR DESCRIPTION
- [x] guarantee termination by adding an (optional) timeout to `releaseLogger`.
- [x] add respawn logic and configurable exception handlers for backend. Decide whether this
     should be configurable for the user of the logger, the user of an backend, or only for the author 
     of a backend.
- [x] investigate if respawn logic and configurable handlers are needed for the logger itself.
- [x] add means to log errors in log-system to an alternate sink (e.g. stderr).
