### PR TITLE
Fix spelling error (*ToMany → *TooMany)

### DIFF
--- a/src/System/Logger/Logger/Internal.hs
+++ b/src/System/Logger/Logger/Internal.hs
@@ -127,7 +127,7 @@ data LoggerConfig = LoggerConfig
         -- ^ how to deal with a congested logging pipeline
     , _loggerConfigExceptionLimit ∷ !(Maybe Int)
         -- ^ number of consecutive backend exception that can occur before the logger
-        -- raises an 'BackendToManyExceptions' exception. If this is 'Nothing'
+        -- raises an 'BackendTooManyExceptions' exception. If this is 'Nothing'
         -- the logger will discard all exceptions. For instance a value of @1@
         -- means that an exception is raised when the second exception occurs.
         -- A value of @0@ means that an exception is raised for each exception.
@@ -313,7 +313,7 @@ loggerErrLogFunction = lens _loggerErrLogFunction $ \a b → a { _loggerErrLogFu
 --    exception list.
 --
 -- 3. If the length of the exception list exceeds a configurable threshold
---    a 'BackendToManyExceptions' exception is thrown (which causes the logger
+--    a 'BackendTooManyExceptions' exception is thrown (which causes the logger
 --    to terminate).
 --
 -- 4. Otherwise the logger waits for a configurable amount of time before
@@ -386,7 +386,7 @@ backendWorker
         -- ^ alternate sink for logging exceptions in the logger itself.
     → Maybe Int
         -- ^ number of consecutive backend exception that can occur before the logger
-        -- to raises an 'BackendToManyExceptions' exception. If this is 'Nothing'
+        -- to raises an 'BackendTooManyExceptions' exception. If this is 'Nothing'
         -- the logger will discard all exceptions. For instance a value of @1@
         -- means that an exception is raised when the second exception occurs.
         -- A value of @0@ means that an exception is raised for each exception.
@@ -433,7 +433,7 @@ backendWorker errLogFun errLimit errWait backend queue missed = mask_ $
                 case errLimit of
                     Nothing → return []
                     Just n
-                        | length errList' > n → throwIO $ BackendToManyExceptions (reverse errList')
+                        | length errList' > n → throwIO $ BackendTooManyExceptions (reverse errList')
                         | otherwise → return errList'
 
     -- As long as the queue is not closed and empty this retries until

--- a/src/System/Logger/Types.hs
+++ b/src/System/Logger/Types.hs
@@ -234,7 +234,7 @@ type LogScope = [LogLabel]
 data LoggerException a where
     QueueFullException ∷ LogMessage a → LoggerException a
     BackendTerminatedException ∷ SomeException → LoggerException Void
-    BackendToManyExceptions ∷ [SomeException] → LoggerException Void
+    BackendTooManyExceptions ∷ [SomeException] → LoggerException Void
     deriving (Typeable)
 
 deriving instance Show a ⇒ Show (LoggerException a)

--- a/test/NoBackend.hs
+++ b/test/NoBackend.hs
@@ -162,7 +162,7 @@ buggyRecoverBackendTests m n =
 
 -- | Buggy Backend that calls some exception.
 --
--- The logger is expected to throw 'BackendToManyExceptions'.
+-- The logger is expected to throw 'BackendTooManyExceptions'.
 --
 buggyNoRecoverBackendTests ∷ Int → Int → [TestParams] → TestTree
 buggyNoRecoverBackendTests m n =
@@ -176,7 +176,7 @@ buggyNoRecoverBackendTests m n =
             -- and exception.
             assertString $ "Missing expected exception: " ⊕ sshow exception
         `catch` \(e ∷ LoggerException Void) → case e of
-            BackendToManyExceptions (e0:_) → case fromException e0 of
+            BackendTooManyExceptions (e0:_) → case fromException e0 of
                 Just BuggyBackendException → logLogStr $ "test: expected exception: " ⊕ sshow e
                 _ → throwIO e
             _ → throwIO e


### PR DESCRIPTION
Sorry I missed this during review.
