### PR TITLE
Delete orphan MonadTrace instance

### DIFF
--- a/src/System/Logger/Types.hs
+++ b/src/System/Logger/Types.hs
@@ -482,11 +482,6 @@ class LoggerCtx ctx msg | ctx → msg where
 newtype LoggerCtxT ctx m α = LoggerCtxT { unLoggerCtxT ∷ ReaderT ctx m α }
     deriving (Functor, Applicative, Monad, MonadIO, MonadTrans, MonadReader ctx, MonadError a, MonadState a, MonadWriter a, MonadBase a, MonadTrace t)
 
--- This should eventually be defined in Control.Monad.Trace.Class
-instance (Monad m, MonadTrace t m) ⇒ MonadTrace t (ReaderT ctx m) where
-    traceScope s inner = liftWith (\run → traceScope s (run inner)) ≫= restoreT ∘ return
-    readTrace = lift readTrace
-
 instance MonadTransControl (LoggerCtxT ctx) where
     type StT (LoggerCtxT ctx) a = StT (ReaderT ctx) a
     liftWith = defaultLiftWith LoggerCtxT unLoggerCtxT

--- a/yet-another-logger.cabal
+++ b/yet-another-logger.cabal
@@ -111,7 +111,7 @@ Library
         stm-chans >= 3.0,
         text >= 1.2,
         time >= 1.5,
-        trace >= 0.1,
+        trace >= 0.2,
         transformers >= 0.3,
         transformers-base >= 0.4,
         void >= 0.7


### PR DESCRIPTION
I have released a new version of the `trace` package which includes standard `MonadTrace` implementations for the various transformers.

The implementation in  `trace`, however, is the straightforward/standard one: 

``` haskell
traceScope t (ReaderT m) = ReaderT $ traceScope t . m
```

Are you relying on the behavior of the one in this package? If so, can you help me understand what is going is going on in this one, and whether it makes sense to make this the standard implementation?
