### PR TITLE
replace FoldCase by IsText and use simple case folding

### DIFF
--- a/src/System/Logger/Backend/ColorOption.hs
+++ b/src/System/Logger/Backend/ColorOption.hs
@@ -51,15 +51,17 @@ module System.Logger.Backend.ColorOption
 import Configuration.Utils
 
 import Control.DeepSeq
+import Control.Lens
 import Control.Monad.Except
 
-import qualified Data.CaseInsensitive as CI
+import Data.Char (toLower)
 #if ! MIN_VERSION_base(4,8,0)
 import Data.Monoid
 #endif
 import Data.Monoid.Unicode
 import Data.String
 import qualified Data.Text as T
+import Data.Text.Lens
 import Data.Typeable
 
 import GHC.Generics
@@ -85,10 +87,10 @@ data ColorOption
 instance NFData ColorOption
 
 readColorOption
-    ∷ (Monad m, Eq a, Show a, CI.FoldCase a, IsString a, IsString e, Monoid e, MonadError e m)
+    ∷ (Monad m, Eq a, Show a, IsText a, IsString a, IsString e, Monoid e, MonadError e m)
     ⇒ a
     → m ColorOption
-readColorOption x = case CI.mk x of
+readColorOption x = case runIdentity (text (pure . toLower) x) of
     "auto" → return ColorAuto
     "false" → return ColorFalse
     "true" → return ColorTrue

--- a/yet-another-logger.cabal
+++ b/yet-another-logger.cabal
@@ -96,7 +96,6 @@ Library
         base == 4.*,
         base-unicode-symbols >= 0.2,
         bytestring >= 0.10,
-        case-insensitive >= 1.2,
         clock >= 0.4,
         configuration-tools >= 0.2.8,
         deepseq >= 1.3,


### PR DESCRIPTION
The toFoldCase function of Data.Text massively increases compilation times
with recent versions of GHC. In this package the simpler case folding
implementation of the toLower function in Data.Char is sufficient.

This is a backward incompatible API change since the scope of
the respective functions is excludes the ByteString instances of
IsString and FoldCase.
